### PR TITLE
- Refactored the Go-Websocket-Gateway node URL handling to support multiple nodes / varied IP adresses via dedicated command-line flags.

### DIFF
--- a/Blockchain/geth-nodes/docker-compose.yaml
+++ b/Blockchain/geth-nodes/docker-compose.yaml
@@ -192,6 +192,24 @@ services:
     networks:
       - geth-net
 
+  go-websocket:
+    image: keplereum/go-websocket-gateway:latest
+    container_name: go-websocket-gateway
+    environment:
+      - NODE_COUNT=5
+      - NODE_ADDRESSES=geth-node1,geth-node2,geth-node3,geth-node4,geth-node5
+      - NODE_PORTS=8545,8546,8547,8548,8549
+    depends_on:
+      - geth-node1
+      - geth-node2
+      - geth-node3
+      - geth-node4
+      - geth-node5
+    ports:
+      - "8080:8080"
+    networks:
+      - geth-net
+
   geth-exporter:
     image: etclabscore/gethexporter
     container_name: geth-exporter
@@ -202,11 +220,7 @@ services:
       - ADDRESSES=0xe6427a00f96f7ca5688f1de97ba66c21daf77afe,0x8ae4132bc3a5349245e5cb5df336f7bd1c312c44,0x586c6a428dfa031a56360e634cd8d87ea38441c1,0xe680c674b7ee03080c8c11099d499c68895088cb,0x90501ed9e1d4466512a09fe41157a1fad6ed76e7
       - METRICSADDR=0.0.0.0:6061
     depends_on:
-      - geth-node1
-      - geth-node2
-      - geth-node3
-      - geth-node4
-      - geth-node5
+      - nginx-lb
     networks:
       - geth-net
 

--- a/Blockchain_WebSocket_Gateway/Dockerfile
+++ b/Blockchain_WebSocket_Gateway/Dockerfile
@@ -1,15 +1,17 @@
 FROM golang:1.24.2
-
 WORKDIR /app
 
 COPY go.mod go.sum ./
-
 RUN go mod download
-
 COPY . .
 
 RUN go build -o main .
 
 EXPOSE 8080
+# Define environment variables for Ethereum cluster configuration
+ENV NODE_COUNT=${NODE_COUNT}
+ENV NODE_ADDRESSES=${NODE_ADDRESSES}
+ENV NODE_PORTS=${NODE_PORTS}
 
-CMD ["./main", "--host", "${ETHEREUM_CLUSTER_IP}"]
+# Run the application with the environment variables passed as flags
+CMD ./main --nodes=${NODE_COUNT} --addresses=${NODE_ADDRESSES} --ports=${NODE_PORTS}

--- a/Blockchain_WebSocket_Gateway/main.go
+++ b/Blockchain_WebSocket_Gateway/main.go
@@ -2,56 +2,68 @@ package main
 
 import (
 	"flag"
-    "fmt"
+	"fmt"
 	"log"
 	"net/http"
+	"strings"
+
 	"github.com/gorilla/mux"
 	"github.com/sch0penheimer/eth-ws-server/blockchain"
 	"github.com/sch0penheimer/eth-ws-server/websocket"
 )
 
 func main() {
-	hostFlag := flag.String("host", "", "Host IP address of the Ethereum node cluster (e.g., 192.168.240.222)")
+	nodeCount := flag.Int("nodes", 0, "Total number of nodes")
+	nodeAddresses := flag.String("addresses", "", "Comma-separated list of node IP addresses")
+	nodePorts := flag.String("ports", "", "Comma-separated list of node ports")
 	flag.Parse()
 
-    if *hostFlag == "" {
-        log.Fatal("No host IP address provided. Use the --host flag to specify the host IP.")
-    }
+	if *nodeCount <= 0 {
+		log.Fatal("Invalid or missing node count. Use the --nodes flag to specify the total number of nodes.")
+	}
+	if *nodeAddresses == "" || *nodePorts == "" {
+		log.Fatal("Node addresses and ports must be provided. Use --addresses and --ports flags.")
+	}
 
-	/** Dynamically format the node URLs using the host IP :
-	 *  In my private Ethereum PoA Blockchain my 
-	 *	connecting node was setuped with WebSocket instead of HTTP, like the rest of the nodes. 
-	 */
-    nodeURLs := []string{
-        fmt.Sprintf("ws://%s:8545", *hostFlag),
-        fmt.Sprintf("http://%s:8546", *hostFlag),
-        fmt.Sprintf("http://%s:8547", *hostFlag),
-        fmt.Sprintf("http://%s:8548", *hostFlag),
-        fmt.Sprintf("http://%s:8549", *hostFlag),
-    }
+	addressList := strings.Split(*nodeAddresses, ",")
+	portList := strings.Split(*nodePorts, ",")
 
-    log.Printf("Using the following WebSocket node URLs: %v", nodeURLs)
+	if len(addressList) != *nodeCount || len(portList) != *nodeCount {
+		log.Fatalf("The number of addresses (%d) and ports (%d) must match the node count (%d).", len(addressList), len(portList), *nodeCount)
+	}
 
+	nodeURLs := make([]string, *nodeCount)
+	for i := 0; i < *nodeCount; i++ {
+		if i == 0 {
+			nodeURLs[i] = fmt.Sprintf("ws://%s:%s", addressList[i], portList[i])
+		} else {
+			nodeURLs[i] = fmt.Sprintf("http://%s:%s", addressList[i], portList[i])
+		}
+	}
+
+	log.Printf("Using the following node URLs: %v", nodeURLs)
+
+	// Initialize the mining controller
 	miningController, err := blockchain.NewMiningController(nodeURLs)
 	if err != nil {
 		log.Fatalf("Failed to initialize mining controller: %v", err)
 	}
 
-	//* Initializing the blockchain client && the WS Handler *//
+	// Initialize the blockchain client and WebSocket handler
 	blockFetcher, err := blockchain.NewBlockFetcher(nodeURLs[0])
 	if err != nil {
 		log.Fatalf("Failed to initialize blockchain client: %v", err)
 	}
 	wsHandler := websocket.NewWSHandler(blockFetcher, miningController)
 
-	
+	// Set up the HTTP server
 	r := mux.NewRouter()
 	r.HandleFunc("/ws", wsHandler.HandleConnections)
 	r.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))
 	})
 
-
+	// Add CORS middleware
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
Running Example: (go run main.go --nodes={number} --adresses={commaSeparatedAdresses} --ports={commaSeparatedPorts})